### PR TITLE
Bugfix tmp directory

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -50,7 +50,10 @@ FROM scratch
 
 COPY --from=builder ./app/dist/run-exe /dist/
 
-WORKDIR /tmp
+# Mark tmp folder to be mounted externally to give container runtime a chance to clean up.
+# This is a workaround for the missing tmpfs mount in 'scratch' containers.
+VOLUME /tmp
+
 WORKDIR /dist
 
 ENV PATH="/dist:$PATH"


### PR DESCRIPTION
# Description

Fixed the behaviour of the `/tmp` folder inside of the app container. The tmp folder is now marked as a Docker `VOLUME`, so that the container runtime can properly mount it externally and cleaning it up. A better way would be a actually create `/tmp` as tmpfs, but that's not so easy in `scratch` containers.

Background: We identified a problem when doing stress testing on real hardware (hard power-off cycles of phyiscal devices while an app based on this template was running) and it was committing +50MB on each power-off cycle. The root cause is that `staticx`'s clean up handler is not being invoked when the container is forcefully killed and `/tmp` being a normal folder, which will then pile up additional disk resources each time staticx is starting up, extracting the application archive into tmp etc. 

As this is a template repository, the problem would be multiplying if not fixed. For each app and for each hard poweroff, the disk usage is at least +18MB (minimal dependencies).

By using a volume, the container runtime (or admin) is supposed to mount this into a real tmpfs, which is then cleaned properly, even for hard power-off cycles.

This could have been tested properly by running the container in read-only mode.

Fixed also a typo in the Dockerfile (WORKDIR was mentioned twice without any changes in between, does not make any sense).
